### PR TITLE
fix(ci): Remove no-commit-to-branch pre-commit for CI in master

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,4 +26,3 @@ repos:
       - id: check-merge-conflict
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      - id: no-commit-to-branch


### PR DESCRIPTION
`no-commit-to-branch` fails to execute in the CI of the master branch, this commit removes the pre-commit hook