### PR TITLE
Add required CloudBuild parameters and permissions

### DIFF
--- a/modules/cloud-scanning/README.md
+++ b/modules/cloud-scanning/README.md
@@ -39,7 +39,9 @@ No modules.
 | Name | Type |
 |------|------|
 | [google_cloud_run_service.cloud_scanning](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_service) | resource |
+| [google_project_iam_member.artifactregistry_reader](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.cloudbuild](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.containerregistry_reader](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.logging](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_pubsub_subscription.gcr_sub](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription) | resource |
 | [google_pubsub_subscription_iam_member.editor](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription_iam_member) | resource |

--- a/modules/cloud-scanning/README.md
+++ b/modules/cloud-scanning/README.md
@@ -38,12 +38,20 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [google_cloud_run_service.cloud_connector](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_service) | resource |
+| [google_cloud_run_service.cloud_scanning](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_service) | resource |
 | [google_project_iam_member.cloudbuild](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.logging](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_pubsub_subscription.gcr_sub](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription) | resource |
 | [google_pubsub_subscription_iam_member.editor](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription_iam_member) | resource |
+| [google_secret_manager_secret.secure_token](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret) | resource |
+| [google_secret_manager_secret_iam_member.member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
+| [google_secret_manager_secret_version.secret_version](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_version) | resource |
+| [google_service_account.cloudbuild](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_account.sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_service_account_iam_member.builder](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
+| [google_storage_bucket.logs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket) | resource |
+| [google_storage_bucket_iam_member.bucket_logger](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
+| [google_storage_bucket_iam_member.bucket_object_logger](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
 | [google_project.project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
 
 ## Inputs

--- a/modules/cloud-scanning/main.tf
+++ b/modules/cloud-scanning/main.tf
@@ -5,6 +5,10 @@ locals {
       value = var.sysdig_secure_endpoint
     },
     {
+      name  = "SECURE_API_TOKEN_SECRET"
+      value = google_secret_manager_secret.secure_token.secret_id
+    },
+    {
       name  = "VERIFY_SSL"
       value = tostring(var.verify_ssl)
     },
@@ -22,7 +26,15 @@ locals {
     },
     {
       name  = "AUDITLOG_INTERVAL"
-      value = "30s"
+      value = "1m"
+    },
+    {
+      name  = "CLOUDBUILD_SERVICE_ACCOUNT"
+      value = google_service_account.cloudbuild.email
+    },
+    {
+      name  = "CLOUDBUILD_BUCKET"
+      value = google_storage_bucket.logs.name
     },
     {
       name  = "TELEMETRY_DEPLOYMENT_METHOD"
@@ -50,7 +62,6 @@ resource "google_service_account" "sa" {
   display_name = "Service account for cloudscanning"
 }
 
-
 #TODO: Specific role for reading from specific logs only?
 resource "google_project_iam_member" "logging" {
   member = "serviceAccount:${google_service_account.sa.email}"
@@ -68,6 +79,12 @@ resource "google_pubsub_subscription_iam_member" "editor" {
   member       = "serviceAccount:${google_service_account.sa.email}"
 }
 
+resource "google_service_account_iam_member" "builder" {
+  service_account_id = google_service_account.cloudbuild.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.sa.email}"
+}
+
 resource "google_pubsub_subscription" "gcr_sub" {
   name = "${lower(var.naming_prefix)}-cloudscanning"
 
@@ -81,7 +98,49 @@ resource "google_pubsub_subscription" "gcr_sub" {
   enable_message_ordering = false
 }
 
-resource "google_cloud_run_service" "cloud_connector" {
+resource "google_secret_manager_secret" "secure_token" {
+  secret_id = "${lower(var.naming_prefix)}-secure-api-token"
+  replication {
+    automatic = true
+  }
+}
+
+resource "google_secret_manager_secret_version" "secret_version" {
+  secret      = google_secret_manager_secret.secure_token.id
+  secret_data = var.sysdig_secure_api_token
+}
+
+resource "google_service_account" "cloudbuild" {
+  account_id   = "${lower(var.naming_prefix)}-cloudbuild"
+  display_name = "Service account for executing the scanning Cloud Build"
+}
+
+resource "google_secret_manager_secret_iam_member" "member" {
+  project   = google_secret_manager_secret.secure_token.project
+  secret_id = google_secret_manager_secret.secure_token.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.cloudbuild.email}"
+}
+
+resource "google_storage_bucket" "logs" {
+  project       = data.google_project.project.name
+  name          = "${lower(var.naming_prefix)}-scanning-logs"
+  force_destroy = true
+}
+
+resource "google_storage_bucket_iam_member" "bucket_object_logger" {
+  bucket = google_storage_bucket.logs.id
+  member = "serviceAccount:${google_service_account.cloudbuild.email}"
+  role   = "roles/storage.objectAdmin"
+}
+
+resource "google_storage_bucket_iam_member" "bucket_logger" {
+  bucket = google_storage_bucket.logs.id
+  member = "serviceAccount:${google_service_account.cloudbuild.email}"
+  role   = "roles/storage.admin"
+}
+
+resource "google_cloud_run_service" "cloud_scanning" {
   depends_on = [google_project_iam_member.logging]
   location   = var.location
   name       = "${substr(lower(var.naming_prefix), 0, 49)}-cloudscanning"

--- a/modules/cloud-scanning/main.tf
+++ b/modules/cloud-scanning/main.tf
@@ -115,6 +115,16 @@ resource "google_service_account" "cloudbuild" {
   display_name = "Service account for executing the scanning Cloud Build"
 }
 
+resource "google_project_iam_member" "artifactregistry_reader" {
+  member = "serviceAccount:${google_service_account.cloudbuild.email}"
+  role   = "roles/artifactregistry.reader"
+}
+
+resource "google_project_iam_member" "containerregistry_reader" {
+  member = "serviceAccount:${google_service_account.cloudbuild.email}"
+  role   = "roles/storage.objectViewer"
+}
+
 resource "google_secret_manager_secret_iam_member" "member" {
   project   = google_secret_manager_secret.secure_token.project
   secret_id = google_secret_manager_secret.secure_token.secret_id


### PR DESCRIPTION
Add a service account to execute the CloudBuild scanning, along with a Bucket for the log and required permissions.

Update poll interval to 1 minute.