### PR TITLE
feat: Add naming_prefix, increase logging, remove max instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ No resources.
 |------|-------------|------|---------|:--------:|
 | <a name="input_cloudconnector_deploy"></a> [cloudconnector\_deploy](#input\_cloudconnector\_deploy) | Whether to deploy or not CloudConnector | `bool` | `true` | no |
 | <a name="input_location"></a> [location](#input\_location) | Zone where the stack will be deployed | `string` | `"us-central1"` | no |
+| <a name="input_naming_prefix"></a> [naming\_prefix](#input\_naming\_prefix) | Naming prefix for all the resources created | `string` | `""` | no |
 | <a name="input_sysdig_secure_api_token"></a> [sysdig\_secure\_api\_token](#input\_sysdig\_secure\_api\_token) | Sysdig's Secure API Token | `string` | n/a | yes |
 | <a name="input_sysdig_secure_endpoint"></a> [sysdig\_secure\_endpoint](#input\_sysdig\_secure\_endpoint) | Sysdig Secure API endpoint | `string` | `"https://secure.sysdig.com"` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -12,4 +12,5 @@ module "cloud_connector" {
   sysdig_secure_api_token = var.sysdig_secure_api_token
   sysdig_secure_endpoint  = var.sysdig_secure_endpoint
   verify_ssl              = local.verify_ssl
+  naming_prefix           = var.naming_prefix
 }

--- a/modules/cloud-connector/README.md
+++ b/modules/cloud-connector/README.md
@@ -67,6 +67,7 @@ No modules.
 | <a name="input_extra_envs"></a> [extra\_envs](#input\_extra\_envs) | Extra environment variables for the Cloud Connector instance | `map(string)` | `{}` | no |
 | <a name="input_image_name"></a> [image\_name](#input\_image\_name) | Cloud Connector image to deploy | `string` | `"gcr.io/mateo-burillo-ns/cloud-connector:master"` | no |
 | <a name="input_location"></a> [location](#input\_location) | Zone where the cloud connector will be deployed | `string` | `"us-central1"` | no |
+| <a name="input_max_instances"></a> [max\_instances](#input\_max\_instances) | Max number of instances for the Cloud Connector | `number` | `1` | no |
 | <a name="input_naming_prefix"></a> [naming\_prefix](#input\_naming\_prefix) | Naming prefix for all the resources created | `string` | `""` | no |
 | <a name="input_sysdig_secure_api_token"></a> [sysdig\_secure\_api\_token](#input\_sysdig\_secure\_api\_token) | Sysdig's Secure API Token | `string` | n/a | yes |
 | <a name="input_sysdig_secure_endpoint"></a> [sysdig\_secure\_endpoint](#input\_sysdig\_secure\_endpoint) | Sysdig's Secure API URL | `string` | n/a | yes |

--- a/modules/cloud-connector/README.md
+++ b/modules/cloud-connector/README.md
@@ -67,6 +67,7 @@ No modules.
 | <a name="input_extra_envs"></a> [extra\_envs](#input\_extra\_envs) | Extra environment variables for the Cloud Connector instance | `map(string)` | `{}` | no |
 | <a name="input_image_name"></a> [image\_name](#input\_image\_name) | Cloud Connector image to deploy | `string` | `"gcr.io/mateo-burillo-ns/cloud-connector:master"` | no |
 | <a name="input_location"></a> [location](#input\_location) | Zone where the cloud connector will be deployed | `string` | `"us-central1"` | no |
+| <a name="input_naming_prefix"></a> [naming\_prefix](#input\_naming\_prefix) | Naming prefix for all the resources created | `string` | `""` | no |
 | <a name="input_sysdig_secure_api_token"></a> [sysdig\_secure\_api\_token](#input\_sysdig\_secure\_api\_token) | Sysdig's Secure API Token | `string` | n/a | yes |
 | <a name="input_sysdig_secure_endpoint"></a> [sysdig\_secure\_endpoint](#input\_sysdig\_secure\_endpoint) | Sysdig's Secure API URL | `string` | n/a | yes |
 | <a name="input_verify_ssl"></a> [verify\_ssl](#input\_verify\_ssl) | Verify the SSL certificate of the Secure endpoint | `bool` | `true` | no |

--- a/modules/cloud-connector/main.tf
+++ b/modules/cloud-connector/main.tf
@@ -167,6 +167,12 @@ resource "google_cloud_run_service" "cloud_connector" {
   }
 
   template {
+    metadata {
+      annotations = {
+        "autoscaling.knative.dev/maxScale" = tostring(var.max_instances)
+      }
+    }
+
     spec {
       containers {
         image = var.image_name

--- a/modules/cloud-connector/main.tf
+++ b/modules/cloud-connector/main.tf
@@ -33,13 +33,14 @@ ingestors:
 notifiers: []
 EOF
   config_content = var.config_content == null && var.config_source == null ? local.default_config : var.config_content
+  naming_prefix  = var.naming_prefix == "" ? "" : "${var.naming_prefix}-"
 }
 
 data "google_project" "project" {
 }
 
 resource "google_service_account" "sa" {
-  account_id   = "cloud-connector"
+  account_id   = "${local.naming_prefix}cloud-connector"
   display_name = "Service account for cloud-connector"
 }
 
@@ -68,7 +69,7 @@ resource "random_string" "random" {
 }
 
 resource "google_storage_bucket" "bucket" {
-  name          = "${var.bucket_config_name}-${random_string.random.result}"
+  name          = "${local.naming_prefix}${var.bucket_config_name}-${random_string.random.result}"
   force_destroy = true
   versioning {
     # TODO Can we disable the versioning in this bucket, since the content is managed by Terraform?
@@ -84,15 +85,16 @@ resource "google_storage_bucket_object" "config" {
 }
 
 resource "google_pubsub_topic" "topic" {
-  name = "cloud-connector-topic"
+  name = "${local.naming_prefix}cloud-connector-topic"
 }
 
 resource "google_logging_project_sink" "project_sink" {
-  name                   = "cloud-connector-project-sink"
+  depends_on             = [google_pubsub_topic.topic]
+  name                   = "${local.naming_prefix}cloud-connector-project-sink"
   destination            = "pubsub.googleapis.com/${google_pubsub_topic.topic.id}"
   unique_writer_identity = true
   filter                 = <<EOT
-  logName="projects/${data.google_project.project.project_id}/logs/cloudaudit.googleapis.com%2Factivity" AND -resource.type="k8s_cluster"
+  logName=~"^projects/${data.google_project.project.project_id}/logs/cloudaudit.googleapis.com" AND -resource.type="k8s_cluster"
 EOT
 }
 
@@ -122,7 +124,7 @@ resource "google_project_iam_member" "token_creator" {
 }
 
 resource "google_eventarc_trigger" "trigger" {
-  name            = "cloud-connector-trigger"
+  name            = "${local.naming_prefix}cloud-connector-trigger"
   location        = var.location
   service_account = google_service_account.sa.email
   matching_criteria {
@@ -146,7 +148,7 @@ resource "google_eventarc_trigger" "trigger" {
 resource "google_cloud_run_service" "cloud_connector" {
   depends_on = [google_project_iam_member.logging, google_storage_bucket_iam_member.read_access, google_storage_bucket_iam_member.list_objects]
   location   = var.location
-  name       = "cloud-connector"
+  name       = "${local.naming_prefix}cloud-connector"
 
   lifecycle {
     # We ignore changes in some annotations Cloud Run adds to the resource so we can
@@ -160,18 +162,12 @@ resource "google_cloud_run_service" "cloud_connector" {
 
   metadata {
     annotations = {
-      "run.googleapis.com/launch-stage" = "BETA"
+      "run.googleapis.com/ingress" = "internal"
     }
   }
 
   template {
-    metadata {
-      annotations = {
-        "autoscaling.knative.dev/maxScale" = "1"
-      }
-    }
     spec {
-      container_concurrency = 1
       containers {
         image = var.image_name
 

--- a/modules/cloud-connector/variables.tf
+++ b/modules/cloud-connector/variables.tf
@@ -50,3 +50,9 @@ variable "config_source" {
   type        = string
   description = "Path to a file that contains the contents of the configuration file to be saved in the bucket"
 }
+
+variable "naming_prefix" {
+  type        = string
+  description = "Naming prefix for all the resources created"
+  default     = ""
+}

--- a/modules/cloud-connector/variables.tf
+++ b/modules/cloud-connector/variables.tf
@@ -56,3 +56,9 @@ variable "naming_prefix" {
   description = "Naming prefix for all the resources created"
   default     = ""
 }
+
+variable "max_instances" {
+  type        = number
+  description = "Max number of instances for the Cloud Connector"
+  default     = 1
+}

--- a/variables.tf
+++ b/variables.tf
@@ -20,3 +20,9 @@ variable "sysdig_secure_endpoint" {
   default     = "https://secure.sysdig.com"
   description = "Sysdig Secure API endpoint"
 }
+
+variable "naming_prefix" {
+  type        = string
+  description = "Naming prefix for all the resources created"
+  default     = ""
+}


### PR DESCRIPTION
This PR modifies:
- Adds the `naming_prefix` variable that was removed in previous versions.
- Increases the logging retrieved from PubSub to retrieve also the data_access logs.
- Add `max_instances` variable to be able to scale horizontally on large accounts.
- Locks the access to internal resources, so the endpoint is only accessible from PubSub.
