### PR TITLE
chore: Remove unneeded permission

### DIFF
--- a/modules/cloud-connector/README.md
+++ b/modules/cloud-connector/README.md
@@ -45,7 +45,6 @@ No modules.
 | [google_eventarc_trigger.trigger](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/eventarc_trigger) | resource |
 | [google_logging_project_sink.project_sink](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/logging_project_sink) | resource |
 | [google_project_iam_member.event_receiver](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_project_iam_member.logging](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.token_creator](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_pubsub_topic.topic](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic) | resource |
 | [google_pubsub_topic_iam_member.writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic_iam_member) | resource |

--- a/modules/cloud-connector/main.tf
+++ b/modules/cloud-connector/main.tf
@@ -44,12 +44,6 @@ resource "google_service_account" "sa" {
   display_name = "Service account for cloud-connector"
 }
 
-#TODO: Specific role for reading from required logs only?
-resource "google_project_iam_member" "logging" {
-  member = "serviceAccount:${google_service_account.sa.email}"
-  role   = "roles/logging.viewer"
-}
-
 resource "google_storage_bucket_iam_member" "read_access" {
   bucket = google_storage_bucket.bucket.id
   member = "serviceAccount:${google_service_account.sa.email}"
@@ -146,7 +140,7 @@ resource "google_eventarc_trigger" "trigger" {
 }
 
 resource "google_cloud_run_service" "cloud_connector" {
-  depends_on = [google_project_iam_member.logging, google_storage_bucket_iam_member.read_access, google_storage_bucket_iam_member.list_objects]
+  depends_on = [google_storage_bucket_iam_member.read_access, google_storage_bucket_iam_member.list_objects]
   location   = var.location
   name       = "${local.naming_prefix}cloud-connector"
 


### PR DESCRIPTION
Removes unneeded `roles/logging.viewer` permission, since the logs will be received through HTTP requests via PubSub