### PR TITLE
feat: Add cloud-scanning module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cloud Vision deploy in GCP Module
 
-This repository contains a Module for how to deploy the Cloud Vision in the Google Cloud Platform with different components
-deployment that will detect events in your infrastructure.
+This repository contains a Module for how to deploy the Cloud Vision in the Google Cloud Platform with different
+components deployment that will detect events in your infrastructure.
 
 ## Usage
 
@@ -9,8 +9,9 @@ deployment that will detect events in your infrastructure.
 module "cloud_vision_gcp" {
   source = "sysdiglabs/cloudvision/google"
 
-  location = "us-central1"
+  location                = "us-central1"
   sysdig_secure_api_token = "00000000-1111-2222-3333-444444444444"
+  create_gcr_topic        = true # Set to "false" if the PubSub topic called "gcr" already exists.
 }
 ```
 
@@ -31,6 +32,7 @@ No providers.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_cloud_connector"></a> [cloud\_connector](#module\_cloud\_connector) | ./modules/cloud-connector |  |
+| <a name="module_cloud_scanning"></a> [cloud\_scanning](#module\_cloud\_scanning) | ./modules/cloud-scanning |  |
 
 ## Resources
 
@@ -41,6 +43,8 @@ No resources.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_cloudconnector_deploy"></a> [cloudconnector\_deploy](#input\_cloudconnector\_deploy) | Whether to deploy or not CloudConnector | `bool` | `true` | no |
+| <a name="input_cloudscanning_deploy"></a> [cloudscanning\_deploy](#input\_cloudscanning\_deploy) | Whether to deploy or not CloudConnector | `bool` | `true` | no |
+| <a name="input_create_gcr_topic"></a> [create\_gcr\_topic](#input\_create\_gcr\_topic) | Deploys a PubSub topic called `gcr` as part of this stack, which is needed for GCR scanning. Set to `true` if it doesn't exist yet. If this is not deployed, and no existing `gcr` topic is found, the GCR scanning is ommited and won't be deployed. For more info see [GCR PubSub topic](https://cloud.google.com/container-registry/docs/configuring-notifications#create_a_topic). | `bool` | `false` | no |
 | <a name="input_location"></a> [location](#input\_location) | Zone where the stack will be deployed | `string` | `"us-central1"` | no |
 | <a name="input_naming_prefix"></a> [naming\_prefix](#input\_naming\_prefix) | Naming prefix for all the resources created | `string` | `""` | no |
 | <a name="input_sysdig_secure_api_token"></a> [sysdig\_secure\_api\_token](#input\_sysdig\_secure\_api\_token) | Sysdig's Secure API Token | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,9 @@
 locals {
-  deploy_cloudconnector = var.cloudconnector_deploy
-  verify_ssl            = length(regexall("^https://.*?\\.sysdig.com/?", var.sysdig_secure_endpoint)) != 0
+  verify_ssl = length(regexall("^https://.*?\\.sysdig.com/?", var.sysdig_secure_endpoint)) != 0
 }
 
 module "cloud_connector" {
-  count = local.deploy_cloudconnector ? 1 : 0
+  count = var.cloudconnector_deploy ? 1 : 0
 
   source = "./modules/cloud-connector"
 
@@ -13,4 +12,16 @@ module "cloud_connector" {
   sysdig_secure_endpoint  = var.sysdig_secure_endpoint
   verify_ssl              = local.verify_ssl
   naming_prefix           = var.naming_prefix
+}
+
+module "cloud_scanning" {
+  count  = var.cloudscanning_deploy ? 1 : 0
+  source = "./modules/cloud-scanning"
+
+  location                = var.location
+  sysdig_secure_api_token = var.sysdig_secure_api_token
+  sysdig_secure_endpoint  = var.sysdig_secure_endpoint
+  verify_ssl              = local.verify_ssl
+  naming_prefix           = var.naming_prefix
+  create_gcr_topic        = var.create_gcr_topic
 }

--- a/modules/cloud-scanning/README.md
+++ b/modules/cloud-scanning/README.md
@@ -1,0 +1,82 @@
+# Cloud Scanning deploy in GCP Module
+
+This repository contains a Module for how to deploy the Cloud Scanning in the Google Cloud Platform as a Cloud Run
+deployment that trigger image scans based on changes in your infrastructure.
+
+## Usage
+
+```hcl
+module "cloud_scanning_gcp" {
+  source = "sysdiglabs/cloudvision/google/modules/cloud-scanning"
+
+  create_gcr_topic        = true # Set to "false" if there's an existing PubSub topic called "gcr"
+  sysdig_secure_api_token = "00000000-1111-2222-3333-444444444444"
+  sysdig_secure_endpoint  = "https://secure.sysdig.com"
+}
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.67.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.67.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_cloud_run_service.cloud_scanning](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_service) | resource |
+| [google_cloud_run_service_iam_member.run_invoker](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_service_iam_member) | resource |
+| [google_eventarc_trigger.cloud_run](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/eventarc_trigger) | resource |
+| [google_eventarc_trigger.gcr](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/eventarc_trigger) | resource |
+| [google_logging_project_sink.project_sink](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/logging_project_sink) | resource |
+| [google_project_iam_member.builder](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.event_receiver](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.token_creator](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_pubsub_topic.gcr](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic) | resource |
+| [google_pubsub_topic.topic](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic) | resource |
+| [google_pubsub_topic_iam_member.writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic_iam_member) | resource |
+| [google_secret_manager_secret.secure_api_secret](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret) | resource |
+| [google_secret_manager_secret_version.secure_api_secret](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_version) | resource |
+| [google_service_account.sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_project.project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
+| [google_pubsub_topic.gcr](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/pubsub_topic) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_create_gcr_topic"></a> [create\_gcr\_topic](#input\_create\_gcr\_topic) | Deploys a PubSub topic called `gcr` as part of this stack, which is needed for GCR scanning. Set to `true` only if it doesn't exist yet. If this is not deployed, and no existing `gcr` topic is found, the GCR scanning is ommited and won't be deployed. For more info see [GCR PubSub topic](https://cloud.google.com/container-registry/docs/configuring-notifications#create_a_topic). | `bool` | n/a | yes |
+| <a name="input_extra_envs"></a> [extra\_envs](#input\_extra\_envs) | Extra environment variables for the Cloud Scanning instance | `map(string)` | `{}` | no |
+| <a name="input_image_name"></a> [image\_name](#input\_image\_name) | Cloud scanning image to deploy | `string` | `"gcr.io/mateo-burillo-ns/cloud-scanning:master"` | no |
+| <a name="input_location"></a> [location](#input\_location) | Zone where the cloud scanning will be deployed | `string` | `"us-central1"` | no |
+| <a name="input_max_instances"></a> [max\_instances](#input\_max\_instances) | Max number of instances for the Cloud Scanning | `number` | `1` | no |
+| <a name="input_naming_prefix"></a> [naming\_prefix](#input\_naming\_prefix) | Naming prefix for all the resources created | `string` | `""` | no |
+| <a name="input_sysdig_secure_api_token"></a> [sysdig\_secure\_api\_token](#input\_sysdig\_secure\_api\_token) | Sysdig's Secure API Token | `string` | n/a | yes |
+| <a name="input_sysdig_secure_endpoint"></a> [sysdig\_secure\_endpoint](#input\_sysdig\_secure\_endpoint) | Sysdig's Secure API URL | `string` | n/a | yes |
+| <a name="input_verify_ssl"></a> [verify\_ssl](#input\_verify\_ssl) | Verify the SSL certificate of the Secure endpoint | `bool` | `true` | no |
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## Authors
+
+Module is maintained by [Sysdig](https://github.com/sysdiglabs/terraform-google-cloudvision).
+
+## License
+
+Apache 2 Licensed. See LICENSE for full details.

--- a/modules/cloud-scanning/main.tf
+++ b/modules/cloud-scanning/main.tf
@@ -1,0 +1,206 @@
+locals {
+  task_env_vars = concat([
+    {
+      name  = "SECURE_URL"
+      value = var.sysdig_secure_endpoint
+    },
+    {
+      name  = "VERIFY_SSL"
+      value = tostring(var.verify_ssl)
+    },
+    {
+      name  = "GCP_PROJECT"
+      value = data.google_project.project.project_id
+    },
+    {
+      name  = "SECURE_API_TOKEN_SECRET"
+      value = google_secret_manager_secret.secure_api_secret.secret_id
+    }
+    ], [for env_key, env_value in var.extra_envs :
+    {
+      name  = env_key,
+      value = env_value
+    }
+    ]
+  )
+  naming_prefix = var.naming_prefix == "" ? "" : "${var.naming_prefix}-"
+}
+
+data "google_project" "project" {
+}
+
+resource "google_service_account" "sa" {
+  account_id   = "${local.naming_prefix}cloud-scanning"
+  display_name = "Service account for cloud-scanning"
+}
+
+resource "google_pubsub_topic" "topic" {
+  name = "${local.naming_prefix}cloud-scanning-topic"
+}
+
+resource "google_logging_project_sink" "project_sink" {
+  depends_on             = [google_pubsub_topic.topic]
+  name                   = "${local.naming_prefix}cloud-scanning-project-sink"
+  destination            = "pubsub.googleapis.com/${google_pubsub_topic.topic.id}"
+  unique_writer_identity = true
+  filter                 = <<EOT
+  protoPayload.methodName = "google.cloud.run.v1.Services.CreateService" OR protoPayload.methodName = "google.cloud.run.v1.Services.ReplaceService"
+EOT
+}
+
+resource "google_pubsub_topic_iam_member" "writer" {
+  project = google_pubsub_topic.topic.project
+  topic   = google_pubsub_topic.topic.name
+  role    = "roles/pubsub.publisher"
+  member  = google_logging_project_sink.project_sink.writer_identity
+}
+
+resource "google_project_iam_member" "event_receiver" {
+  role   = "roles/eventarc.eventReceiver"
+  member = "serviceAccount:${google_service_account.sa.email}"
+}
+
+resource "google_project_iam_member" "builder" {
+  role   = "roles/cloudbuild.builds.builder"
+  member = "serviceAccount:${google_service_account.sa.email}"
+}
+
+resource "google_cloud_run_service_iam_member" "run_invoker" {
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.sa.email}"
+  service  = google_cloud_run_service.cloud_scanning.name
+  project  = google_cloud_run_service.cloud_scanning.project
+  location = google_cloud_run_service.cloud_scanning.location
+}
+
+resource "google_project_iam_member" "token_creator" {
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+  role   = "roles/iam.serviceAccountTokenCreator"
+}
+
+resource "google_secret_manager_secret" "secure_api_secret" {
+  secret_id = "${local.naming_prefix}sysdig-secure-api-secret"
+  replication {
+    automatic = true
+  }
+}
+
+resource "google_secret_manager_secret_version" "secure_api_secret" {
+  secret = google_secret_manager_secret.secure_api_secret.id
+
+  secret_data = var.sysdig_secure_api_token
+}
+
+resource "google_eventarc_trigger" "cloud_run" {
+  name            = "${local.naming_prefix}cloud-scanning-trigger-cloudrun"
+  location        = var.location
+  service_account = google_service_account.sa.email
+  matching_criteria {
+    attribute = "type"
+    value     = "google.cloud.pubsub.topic.v1.messagePublished"
+  }
+  destination {
+    cloud_run_service {
+      service = google_cloud_run_service.cloud_scanning.name
+      region  = var.location
+      path    = "/cloud_run_scanning"
+    }
+  }
+  transport {
+    pubsub {
+      topic = google_pubsub_topic.topic.id
+    }
+  }
+}
+
+resource "google_pubsub_topic" "gcr" {
+  count = var.create_gcr_topic ? 1 : 0
+  name  = "gcr"
+}
+
+data "google_pubsub_topic" "gcr" {
+  name = "gcr" # MUST exist in the infra of the customer, that's the only topic GCR will publish events to.
+}
+
+locals {
+  gcr_topic_id = var.create_gcr_topic ? google_pubsub_topic.gcr[0].id : data.google_pubsub_topic.gcr.id
+}
+
+resource "google_eventarc_trigger" "gcr" {
+  count           = length(local.gcr_topic_id[*]) > 0 ? 1 : 0 # We won't try to deploy this trigger if the GCR topic doesn't exist
+  name            = "${local.naming_prefix}cloud-scanning-trigger-gcr"
+  location        = var.location
+  service_account = google_service_account.sa.email
+  matching_criteria {
+    attribute = "type"
+    value     = "google.cloud.pubsub.topic.v1.messagePublished"
+  }
+  destination {
+    cloud_run_service {
+      service = google_cloud_run_service.cloud_scanning.name
+      region  = var.location
+      path    = "/gcr_scanning"
+    }
+  }
+  transport {
+    pubsub {
+      topic = local.gcr_topic_id
+    }
+  }
+}
+
+
+resource "google_cloud_run_service" "cloud_scanning" {
+  location = var.location
+  name     = "${local.naming_prefix}cloud-scanning"
+
+  lifecycle {
+    # We ignore changes in some annotations Cloud Run adds to the resource so we can
+    # avoid unwanted recreations.
+    ignore_changes = [
+      metadata[0].annotations,
+      metadata[0].labels,
+      template[0].metadata[0].annotations,
+    ]
+  }
+
+  metadata {
+    annotations = {
+      "run.googleapis.com/ingress" = "internal"
+    }
+  }
+
+  template {
+    metadata {
+      annotations = {
+        "autoscaling.knative.dev/maxScale" = tostring(var.max_instances)
+      }
+    }
+
+    spec {
+      containers {
+        image = var.image_name
+
+        ports {
+          container_port = 5000
+        }
+
+        env {
+          #TODO: Put secrets in secretsmanager?
+          name  = "SECURE_API_TOKEN"
+          value = var.sysdig_secure_api_token
+        }
+
+        dynamic "env" {
+          for_each = toset(local.task_env_vars)
+
+          content {
+            name  = env.value.name
+            value = env.value.value
+          }
+        }
+      }
+      service_account_name = google_service_account.sa.email
+    }
+  }
+}

--- a/modules/cloud-scanning/variables.tf
+++ b/modules/cloud-scanning/variables.tf
@@ -1,0 +1,52 @@
+variable "sysdig_secure_api_token" {
+  type        = string
+  description = "Sysdig's Secure API Token"
+  sensitive   = true
+}
+
+variable "sysdig_secure_endpoint" {
+  type        = string
+  description = "Sysdig's Secure API URL"
+
+}
+
+variable "verify_ssl" {
+  type        = bool
+  description = "Verify the SSL certificate of the Secure endpoint"
+  default     = true
+}
+
+variable "location" {
+  type        = string
+  default     = "us-central1"
+  description = "Zone where the cloud scanning will be deployed"
+}
+
+variable "image_name" {
+  type        = string
+  default     = "gcr.io/mateo-burillo-ns/cloud-scanning:master"
+  description = "Cloud scanning image to deploy"
+}
+
+variable "extra_envs" {
+  type        = map(string)
+  default     = {}
+  description = "Extra environment variables for the Cloud Scanning instance"
+}
+
+variable "naming_prefix" {
+  type        = string
+  description = "Naming prefix for all the resources created"
+  default     = ""
+}
+
+variable "max_instances" {
+  type        = number
+  description = "Max number of instances for the Cloud Scanning"
+  default     = 1
+}
+
+variable "create_gcr_topic" {
+  type        = bool
+  description = "Deploys a PubSub topic called `gcr` as part of this stack, which is needed for GCR scanning. Set to `true` only if it doesn't exist yet. If this is not deployed, and no existing `gcr` topic is found, the GCR scanning is ommited and won't be deployed. For more info see [GCR PubSub topic](https://cloud.google.com/container-registry/docs/configuring-notifications#create_a_topic)."
+}

--- a/modules/cloud-scanning/versions.tf
+++ b/modules/cloud-scanning/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.14.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.67.0"
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,12 @@ variable "cloudconnector_deploy" {
   description = "Whether to deploy or not CloudConnector"
 }
 
+variable "cloudscanning_deploy" {
+  type        = bool
+  default     = true
+  description = "Whether to deploy or not CloudConnector"
+}
+
 variable "sysdig_secure_api_token" {
   type        = string
   description = "Sysdig's Secure API Token"
@@ -25,4 +31,10 @@ variable "naming_prefix" {
   type        = string
   description = "Naming prefix for all the resources created"
   default     = ""
+}
+
+variable "create_gcr_topic" {
+  type        = bool
+  description = "Deploys a PubSub topic called `gcr` as part of this stack, which is needed for GCR scanning. Set to `true` if it doesn't exist yet. If this is not deployed, and no existing `gcr` topic is found, the GCR scanning is ommited and won't be deployed. For more info see [GCR PubSub topic](https://cloud.google.com/container-registry/docs/configuring-notifications#create_a_topic)."
+  default     = false
 }


### PR DESCRIPTION
Adds the new cloud-scanning module with PubSub based notifications to the cloud-scanning component. 
The `create_gcr_topic` variable is set to `false` by default to keep the backwards compatibility with existing Terraform deployments.
The `gcr` PubSub topic must exist for cloud-scanning to scan images pushed to GCR. If it doesn't exist, it can be deployed by setting `create_gcr_topic` to `true`.