### PR TITLE
fix: Add required service account and IAM for cloud build

### DIFF
--- a/modules/cloud-scanning/README.md
+++ b/modules/cloud-scanning/README.md
@@ -44,6 +44,7 @@ No modules.
 | [google_logging_project_sink.project_sink](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/logging_project_sink) | resource |
 | [google_project_iam_member.builder](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.event_receiver](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.serivce_account_user_itself](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.token_creator](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_pubsub_topic.gcr](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic) | resource |
 | [google_pubsub_topic.topic](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic) | resource |

--- a/modules/cloud-scanning/main.tf
+++ b/modules/cloud-scanning/main.tf
@@ -13,6 +13,10 @@ locals {
       value = data.google_project.project.project_id
     },
     {
+      name  = "GCP_SERVICE_ACCOUNT"
+      value = google_service_account.sa.email
+    },
+    {
       name  = "SECURE_API_TOKEN_SECRET"
       value = google_secret_manager_secret.secure_api_secret.secret_id
     }
@@ -58,6 +62,16 @@ resource "google_pubsub_topic_iam_member" "writer" {
 resource "google_project_iam_member" "event_receiver" {
   role   = "roles/eventarc.eventReceiver"
   member = "serviceAccount:${google_service_account.sa.email}"
+}
+
+# Required to execute cloud build runs with this same service account
+resource "google_project_iam_member" "serivce_account_user_itself" {
+  role   = "roles/iam.serviceAccountUser"
+  member = "serviceAccount:${google_service_account.sa.email}"
+  condition {
+    expression = "resource.name == \"${google_service_account.sa.email}\""
+    title      = "Impersonate only as itself"
+  }
 }
 
 resource "google_project_iam_member" "builder" {


### PR DESCRIPTION
Adds a required environment variable for cloud-scanning to execute Cloud Build events with a service account, and also creates an IAM privilege for this ServiceAccount to self-impersonate itself in Cloud Build.