### PR TITLE
fix: Add secret access to service account

### DIFF
--- a/modules/cloud-scanning/README.md
+++ b/modules/cloud-scanning/README.md
@@ -57,6 +57,7 @@ No modules.
 | [google_pubsub_topic.topic](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic) | resource |
 | [google_pubsub_topic_iam_member.writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic_iam_member) | resource |
 | [google_secret_manager_secret.secure_api_secret](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret) | resource |
+| [google_secret_manager_secret_iam_member.secret_reader](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
 | [google_secret_manager_secret_version.secure_api_secret](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_version) | resource |
 | [google_service_account.sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_project.project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |

--- a/modules/cloud-scanning/main.tf
+++ b/modules/cloud-scanning/main.tf
@@ -109,6 +109,12 @@ resource "google_project_iam_member" "token_creator" {
   role   = "roles/iam.serviceAccountTokenCreator"
 }
 
+resource "google_secret_manager_secret_iam_member" "secret_reader" {
+  secret_id = google_secret_manager_secret.secure_api_secret.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.sa.email}"
+}
+
 resource "google_project_service" "secret_manager" {
   service = "secretmanager.googleapis.com"
 


### PR DESCRIPTION
There was a missing secret access to be given to the service account that executes the inline image scan.