### PR TITLE
fix: Solve race condition with service account

### DIFF
--- a/modules/cloud-connector/main.tf
+++ b/modules/cloud-connector/main.tf
@@ -147,6 +147,8 @@ resource "google_cloud_run_service_iam_member" "run_invoker" {
 }
 
 resource "google_project_iam_member" "token_creator" {
+  depends_on = [google_project_service.pubsub]
+
   member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
   role   = "roles/iam.serviceAccountTokenCreator"
 }

--- a/modules/cloud-scanning/main.tf
+++ b/modules/cloud-scanning/main.tf
@@ -105,6 +105,8 @@ resource "google_cloud_run_service_iam_member" "run_invoker" {
 }
 
 resource "google_project_iam_member" "token_creator" {
+  depends_on = [google_project_service.pubsub]
+
   member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
   role   = "roles/iam.serviceAccountTokenCreator"
 }


### PR DESCRIPTION
Solve race condition when assigning role to PubSub service account that is being created when the service API is deployed.